### PR TITLE
added git clone

### DIFF
--- a/beginner/contributers_list.md
+++ b/beginner/contributers_list.md
@@ -1,1 +1,2 @@
 1. Rajat Verma (rajat2502)
+2. Nihal Pandey (stark019)

--- a/beginner/json-files/git-commands.json
+++ b/beginner/json-files/git-commands.json
@@ -14,5 +14,9 @@
   {
     "title": "git log",
     "description": "The git commit command provides a log of changes made throughout time."
-  }
+  },
+{
+    "title": "git clone",
+    "description": "The git clone is primarily used to point to an existing repo and make a clone or copy of that repo at in a new directory, at another location. The original repository can be located on the local filesystem or on remote machine accessible supported protocols."
+  },
 ]


### PR DESCRIPTION
git clone is primarily used to point to an existing repo and make a clone or copy of that repo at in a new directory, at another location. The original repository can be located on the local filesystem or on remote machine accessible supported protocols.