### PR TITLE
Added new git command to list: highlighting importance of clear commit messages

### DIFF
--- a/beginner/json-files/git-commands.json
+++ b/beginner/json-files/git-commands.json
@@ -334,4 +334,8 @@
     "title": "git rev-list --count master",
     "description": "count the number of commits on a branch"
   }
+  {
+    "title": "git commit -m 'WIP'",
+    "description": "Rather than a favourite, this is one of the least favourite git commands as it does not provide valuable context regarding changes made. Always try to write useful commit messages."
+  }
 ]

--- a/contributers_list.md
+++ b/contributers_list.md
@@ -91,4 +91,4 @@
 91. Tharindu Dilshan (TharinduDilshan)
 92. Need For Eat (need4eat)
 93. Harry Coureau (hCoureau)
-
+94. Katherine Goff (KatGoff)


### PR DESCRIPTION
Before I became a developer, I would go to meetups and conferences and there would always be a quip about "WIP" (work in progress) commit messages. I have added `git commit -m 'WIP'` to the git command list to highlight the importance of clear commit messages for effective team collaboration.